### PR TITLE
Correctly handle nullable step properties

### DIFF
--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -272,9 +272,14 @@ namespace WorkflowCore.Services.DefinitionStorage
                     else
                     {
                         if ((resolvedValue != null) && (stepProperty.PropertyType.IsAssignableFrom(resolvedValue.GetType())))
+                        {
                             stepProperty.SetValue(pStep, resolvedValue);
+                        }
                         else
-                            stepProperty.SetValue(pStep, System.Convert.ChangeType(resolvedValue, stepProperty.PropertyType));
+                        {
+                            Type conversionType = Nullable.GetUnderlyingType(stepProperty.PropertyType) ?? stepProperty.PropertyType;
+                            stepProperty.SetValue(pStep, System.Convert.ChangeType(resolvedValue, conversionType));
+                        }
                     }
                 }
                 catch (Exception e)

--- a/test/WorkflowCore.IntegrationTests/Scenarios/StoredJsonScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/StoredJsonScenario.cs
@@ -83,5 +83,23 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             data["Counter5"].Should().Be(0);
             data["Counter6"].Should().Be(1);
         }
+
+        [Fact]
+        public void should_execute_json_workflow_with_nullable_step_properties()
+        {
+            var initialData = new DynamicData
+            {
+                ["date"] = "2020-05-22T11:20:37.034Z",
+                ["Counter1"] = 0,
+            };
+
+            var workflowId = StartWorkflow(TestAssets.Utils.GetTestDefinitionJsonNullableProperty(), initialData);
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(10));
+
+            var data = GetData<DynamicData>(workflowId);
+            GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
+            UnhandledStepErrors.Count.Should().Be(0);
+            data["Counter1"].Should().Be(1);
+        }
     }
 }

--- a/test/WorkflowCore.TestAssets/Steps/Counter.cs
+++ b/test/WorkflowCore.TestAssets/Steps/Counter.cs
@@ -9,6 +9,7 @@ namespace WorkflowCore.TestAssets.Steps
     public class Counter : StepBody
     {
         public int Value { get; set; }
+        public DateTime? Date { get; set; }
         public override ExecutionResult Run(IStepExecutionContext context)
         {
             Value++;

--- a/test/WorkflowCore.TestAssets/Utils.cs
+++ b/test/WorkflowCore.TestAssets/Utils.cs
@@ -37,6 +37,11 @@ namespace WorkflowCore.TestAssets
         {
             return File.ReadAllText("stored-def-missing-input-property.json");
         }
+
+        public static string GetTestDefinitionJsonNullableProperty()
+        {
+            return File.ReadAllText("stored-def-nullable-property.json");
+        }
     }
 }
 

--- a/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
+++ b/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
@@ -56,4 +56,10 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="stored-def-nullable-property.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/test/WorkflowCore.TestAssets/stored-def-nullable-property.json
+++ b/test/WorkflowCore.TestAssets/stored-def-nullable-property.json
@@ -1,0 +1,19 @@
+﻿{
+  "Id": "Test",
+  "Version": 1,
+  "Description": "",
+  "DataType": "WorkflowCore.TestAssets.DataTypes.DynamicData, WorkflowCore.TestAssets",
+  "Steps": [
+    {
+      "Id": "Step1",
+      "StepType": "WorkflowCore.TestAssets.Steps.Counter, WorkflowCore.TestAssets",
+      "ErrorBehavior": "Retry",
+      "Inputs": {
+        "Date": "data[\"date\"]"
+      },
+      "Outputs": {
+        "Counter1": "step.Value"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
ChangeType doesn't handle nullable types very well, so we need to call
Nullable.GetUnderlyingType beforehand to extract the underlying type
for nullable properties before the ChangeType call.

Added a test to cover this.