### PR TITLE
With the last change, nullable types could now be consumed. However i…

### DIFF
--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -278,7 +278,7 @@ namespace WorkflowCore.Services.DefinitionStorage
                         else
                         {
                             Type conversionType = Nullable.GetUnderlyingType(stepProperty.PropertyType) ?? stepProperty.PropertyType;
-                            stepProperty.SetValue(pStep, System.Convert.ChangeType(resolvedValue, conversionType));
+                            stepProperty.SetValue(pStep, resolvedValue == null ? null : System.Convert.ChangeType(resolvedValue, conversionType));
                         }
                     }
                 }

--- a/test/WorkflowCore.IntegrationTests/Scenarios/StoredJsonScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/StoredJsonScenario.cs
@@ -101,5 +101,23 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             UnhandledStepErrors.Count.Should().Be(0);
             data["Counter1"].Should().Be(1);
         }
+
+        [Fact]
+        public void should_execute_json_workflow_with_null_step_properties()
+        {
+            var initialData = new DynamicData
+            {
+                ["date"] = null,
+                ["Counter1"] = 0,
+            };
+
+            var workflowId = StartWorkflow(TestAssets.Utils.GetTestDefinitionJsonNullableProperty(), initialData);
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(10));
+
+            var data = GetData<DynamicData>(workflowId);
+            GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
+            UnhandledStepErrors.Count.Should().Be(0);
+            data["Counter1"].Should().Be(1);
+        }
     }
 }


### PR DESCRIPTION
…t didnt accept nullable values for these nullable types as it found the underlying value types and used that. Made a change so that null values can now be accepted. Added a test around null values too