### PR TITLE
Fix nested property evaluation

### DIFF
--- a/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
+++ b/src/WorkflowCore.DSL/Services/DefinitionLoader.cs
@@ -290,7 +290,7 @@ namespace WorkflowCore.Services.DefinitionStorage
             return acn;
         }
 
-            private static Action<IStepBody, object, IStepExecutionContext> BuildObjectInputAction(KeyValuePair<string, object> input, ParameterExpression dataParameter, ParameterExpression contextParameter, ParameterExpression environmentVarsParameter, PropertyInfo stepProperty)
+        private static Action<IStepBody, object, IStepExecutionContext> BuildObjectInputAction(KeyValuePair<string, object> input, ParameterExpression dataParameter, ParameterExpression contextParameter, ParameterExpression environmentVarsParameter, PropertyInfo stepProperty)
         {
             void acn(IStepBody pStep, object pData, IStepExecutionContext pContext)
             {
@@ -310,16 +310,16 @@ namespace WorkflowCore.Services.DefinitionStorage
                             subobj.Remove(prop.Name);
                             subobj.Add(prop.Name.TrimStart('@'), JToken.FromObject(resolvedValue));
                         }
-                    }
 
-                    foreach (var child in subobj.Children<JObject>())
-                        stack.Push(child);
+                        foreach (var child in prop.Children<JObject>())
+                            stack.Push(child);
+                    }
                 }
 
-                stepProperty.SetValue(pStep, destObj);
+                var typedObj = destObj.ToObject(stepProperty.PropertyType);
+                stepProperty.SetValue(pStep, typedObj);
             }
             return acn;
         }
-
     }
 }

--- a/test/WorkflowCore.IntegrationTests/Scenarios/StoredJsonScenario.cs
+++ b/test/WorkflowCore.IntegrationTests/Scenarios/StoredJsonScenario.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using WorkflowCore.Interface;
+﻿using FluentAssertions;
+using System;
 using WorkflowCore.Models;
-using Xunit;
-using FluentAssertions;
-using WorkflowCore.Testing;
 using WorkflowCore.TestAssets.DataTypes;
+using WorkflowCore.Testing;
+using Xunit;
 
 namespace WorkflowCore.IntegrationTests.Scenarios
 {
@@ -24,8 +21,8 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(30));
 
             var data = GetData<CounterBoard>(workflowId);
+            UnhandledStepErrors.Should().BeEmpty();
             GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
-            UnhandledStepErrors.Count.Should().Be(0);
             data.Counter1.Should().Be(1);
             data.Counter2.Should().Be(1);
             data.Counter3.Should().Be(1);
@@ -43,8 +40,8 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(30));
 
             var data = GetData<CounterBoard>(workflowId);
+            UnhandledStepErrors.Should().BeEmpty();
             GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
-            UnhandledStepErrors.Count.Should().Be(0);
             data.Counter1.Should().Be(1);
             data.Counter2.Should().Be(1);
             data.Counter3.Should().Be(1);
@@ -74,8 +71,8 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(30));
 
             var data = GetData<DynamicData>(workflowId);
+            UnhandledStepErrors.Should().BeEmpty();
             GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
-            UnhandledStepErrors.Count.Should().Be(0);
             data["Counter1"].Should().Be(1);
             data["Counter2"].Should().Be(1);
             data["Counter3"].Should().Be(1);
@@ -97,8 +94,8 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(10));
 
             var data = GetData<DynamicData>(workflowId);
+            UnhandledStepErrors.Should().BeEmpty();
             GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
-            UnhandledStepErrors.Count.Should().Be(0);
             data["Counter1"].Should().Be(1);
         }
 
@@ -115,9 +112,34 @@ namespace WorkflowCore.IntegrationTests.Scenarios
             WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(10));
 
             var data = GetData<DynamicData>(workflowId);
+            UnhandledStepErrors.Should().BeEmpty();
             GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
-            UnhandledStepErrors.Count.Should().Be(0);
             data["Counter1"].Should().Be(1);
+        }
+
+        [Fact]
+        public void should_execute_json_workflow_and_evaluate_nested_step_properties()
+        {
+            var initialData = new DynamicData
+            {
+                ["dob"] = new DateTime(2020, 06, 15)
+            };
+
+            var workflowId = StartWorkflow(TestAssets.Utils.GetTestDefinitionJsonNestedProperty(), initialData);
+            WaitForWorkflowToComplete(workflowId, TimeSpan.FromSeconds(10));
+
+            var data = GetData<DynamicData>(workflowId);
+            UnhandledStepErrors.Should().BeEmpty();
+            GetStatus(workflowId).Should().Be(WorkflowStatus.Complete);
+            var expected = new Person
+            {
+                Name = "Test Name",
+                NestedData = new NestedData
+                {
+                    DoB = new DateTime(2020, 06, 15)
+                }
+            };
+            data["Person"].ShouldBeEquivalentTo(expected);
         }
     }
 }

--- a/test/WorkflowCore.TestAssets/DataTypes/Person.cs
+++ b/test/WorkflowCore.TestAssets/DataTypes/Person.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace WorkflowCore.TestAssets.DataTypes
+{
+    public class Person
+    {
+        public string Name { get; set; }
+        public NestedData NestedData { get; set; }
+    }
+
+    public class NestedData
+    {
+        public DateTime DoB { get; set; }
+    }
+}

--- a/test/WorkflowCore.TestAssets/Steps/Nested.cs
+++ b/test/WorkflowCore.TestAssets/Steps/Nested.cs
@@ -1,0 +1,15 @@
+﻿using WorkflowCore.Interface;
+using WorkflowCore.Models;
+using WorkflowCore.TestAssets.DataTypes;
+
+namespace WorkflowCore.TestAssets.Steps
+{
+    public class Nested : StepBody
+    {
+        public Person Person { get; set; }
+        public override ExecutionResult Run(IStepExecutionContext context)
+        {
+            return ExecutionResult.Next();
+        }
+    }
+}

--- a/test/WorkflowCore.TestAssets/Utils.cs
+++ b/test/WorkflowCore.TestAssets/Utils.cs
@@ -42,6 +42,11 @@ namespace WorkflowCore.TestAssets
         {
             return File.ReadAllText("stored-def-nullable-property.json");
         }
+
+        public static string GetTestDefinitionJsonNestedProperty()
+        {
+            return File.ReadAllText("stored-def-nested-property.json");
+        }
     }
 }
 

--- a/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
+++ b/test/WorkflowCore.TestAssets/WorkflowCore.TestAssets.csproj
@@ -57,6 +57,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="stored-def-nested-property.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="stored-def-nullable-property.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/test/WorkflowCore.TestAssets/stored-def-nested-property.json
+++ b/test/WorkflowCore.TestAssets/stored-def-nested-property.json
@@ -1,0 +1,24 @@
+﻿{
+  "Id": "Test",
+  "Version": 1,
+  "Description": "",
+  "DataType": "WorkflowCore.TestAssets.DataTypes.DynamicData, WorkflowCore.TestAssets",
+  "Steps": [
+    {
+      "Id": "Step1",
+      "StepType": "WorkflowCore.TestAssets.Steps.Nested, WorkflowCore.TestAssets",
+      "ErrorBehavior": "Retry",
+      "Inputs": {
+        "Person": {
+          "Name": "Test Name",
+          "NestedData": {
+            "@DoB": "data[\"dob\"]"
+          }
+        }
+      },
+      "Outputs": {
+        "Person": "step.Person"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Moved the foreach child loop inside the foreach property loop so that
nested properties can be evaluated. These get pushed onto the stack
which will then be popped and evaluated on subsequent iterations of the
outer while loop.

#FLO-725